### PR TITLE
Allow proper use of mocha .only syntax

### DIFF
--- a/tasks/mocha_casperjs.js
+++ b/tasks/mocha_casperjs.js
@@ -29,8 +29,7 @@ module.exports = function (grunt) {
       ui: 'bdd'
     });
 
-    var files = [],
-        args = [],
+    var args = [],
         errors = 0,
         done = this.async(),
         binPath = '.bin/mocha-casperjs' + (process.platform === 'win32' ? '.cmd' : ''),
@@ -91,23 +90,11 @@ module.exports = function (grunt) {
       });
     });
 
-    this.files.forEach(function (file) {
-      file.src.filter(function (filepath) {
-        if (!grunt.file.exists(filepath)) {
-          grunt.log.warn('Source file "' + filepath + '" not found.');
-          return false;
-        } else {
-          files.push(filepath);
-          return true;
-        }
-      });
-    });
-
-    async.eachSeries(files, function (file, next) {
+    async.eachSeries(this.files, function (file, next) {
 
       var mochaCasperjs = grunt.util.spawn({
         cmd: mocha_casperjs_path,
-        args: _.flatten([file].concat(args))
+        args: _.flatten(file.src.concat(args))
       }, function (err, result, code) {
         next();
       });


### PR DESCRIPTION
Currently grunt-mocha-casperjs doesn't honour the mocha `.only` syntax properly if there are multiple test files. For the file containing the test it works correctly BUT then continues to run all the other test files too.

After some investigation this turned out to be because the plugin is expanding the file src itself and firing off mocha-casperjs for every file. There's no need to do this as mocha-casperjs can do the expanding for itself.

So, I've patched the plugin to pass each src from `this.files` to mocha-casperjs directly. This now means that mocha-casperjs only gets fired once and so is able to honour the `.only` syntax as designed.
